### PR TITLE
Reset canvas alpha to keep dots visible

### DIFF
--- a/index2.html
+++ b/index2.html
@@ -224,8 +224,12 @@
     let start = performance.now();
     requestAnimationFrame(tick);
     function tick(now){
-      const t = (now - start) / 1000;
-      ctx.clearRect(0, 0, W, H);
+        const t = (now - start) / 1000;
+        ctx.clearRect(0, 0, W, H);
+        // 개별 렌더링 함수에서 globalAlpha를 변경하기 때문에
+        // 프레임 시작 시 항상 기본값으로 초기화하여 누적 투명도로
+        // 인해 점이 보이지 않는 문제를 방지한다.
+        ctx.globalAlpha = 1;
 
       drawStars(t);
       drawVignette();


### PR DESCRIPTION
## Summary
- Reset canvas globalAlpha at the start of each frame to avoid accumulated transparency hiding dots.

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_68b93da9e86883228d52a3888673bfac